### PR TITLE
Verify mocks after test

### DIFF
--- a/Source/Public/ZMTBaseTest.m
+++ b/Source/Public/ZMTBaseTest.m
@@ -122,7 +122,7 @@
 - (void)tearDown
 {
     [self unregisterLogErrorHook];
-    
+    [self verifyMocksNow];
     [super tearDown];
 }
 


### PR DESCRIPTION
I noticed that quite a few tests leak file descriptors - i.e. open file stays open after the test is run. My guess is that it happens because all mocks are retained and not properly torn down without calling this method. The actual performance impact of this is not clear and it doesn't seem to break tests so why not ¯\\\_(ツ)_/¯ 