### PR TITLE
Improving memory usage

### DIFF
--- a/Source/Public/FakeGroupContext.swift
+++ b/Source/Public/FakeGroupContext.swift
@@ -25,8 +25,13 @@ public class FakeGroupContext: NSObject, ZMSGroupQueue {
     public let dispatchGroup: ZMSDispatchGroup!
     fileprivate let queue: DispatchQueue!
     
-    public static let mainContext = FakeGroupContext(queue: DispatchQueue.main, group: ZMSDispatchGroup(label: "FakeGroupContext mainContext"))
-    public static let sycnContext = FakeGroupContext(queue: DispatchQueue(label: "FakeGroupContext syncContext"), group: ZMSDispatchGroup(label: "FakeSyncContext"))
+    public static var main: FakeGroupContext {
+        return FakeGroupContext(queue: DispatchQueue.main, group: ZMSDispatchGroup(label: "FakeGroupContext mainContext"))
+    }
+    
+    public static var sync: FakeGroupContext {
+         return FakeGroupContext(queue: DispatchQueue(label: "FakeGroupContext syncContext"), group: ZMSDispatchGroup(label: "FakeSyncContext"))
+    }
     
     public init(queue: DispatchQueue, group: ZMSDispatchGroup) {
         self.queue = queue

--- a/Source/Public/ZMTBaseTest.m
+++ b/Source/Public/ZMTBaseTest.m
@@ -98,6 +98,7 @@
     self.ignoreLogErrors = NO;
     if (self.logHookToken != nil) {
         [ZMSLog removeLogHookWithToken:_logHookToken];
+        self.logHookToken = nil;
     }
 }
 
@@ -113,8 +114,8 @@
     
     [self registerLogErrorHook];
     
-    self.fakeUIContext = [FakeGroupContext mainContext];
-    self.fakeSyncContext = [FakeGroupContext sycnContext];
+    self.fakeUIContext = [FakeGroupContext main];
+    self.fakeSyncContext = [FakeGroupContext sync];
     
     [NSUUID reseedUUID:self.name];
 }
@@ -123,6 +124,12 @@
 {
     [self unregisterLogErrorHook];
     [self verifyMocksNow];
+    _dispatchGroup = nil;
+    _logHookToken = nil;
+    _fakeUIContext = nil;
+    _fakeSyncContext = nil;
+    _mocksToBeVerified = nil;
+    self.expectations = nil;
     [super tearDown];
 }
 


### PR DESCRIPTION
To improve memory usage we need to nil all the objects created in `setUp` because they stay up for the whole test suite run.