### PR TITLE
Improve leaks checking

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "wireapp/ocmock" "v3.3.2"
-github "wireapp/wire-ios-system" "18.2.0"
+github "wireapp/wire-ios-system" "18.2.1"

--- a/Source/Public/ZMTBaseTest.m
+++ b/Source/Public/ZMTBaseTest.m
@@ -131,16 +131,19 @@
     self.mocksToBeVerified = nil;
     self.expectations = nil;
     [super tearDown];
-    [self checkMemoryReferenceDebuggerForLeaks];
 }
 
-- (void)checkMemoryReferenceDebuggerForLeaks {
-    // some objects, like NSManagedObjectContext with concurrency type .mainQueue, will in some
-    // cases enqueue something on the main queue that will hold on to it. So even if every reference is
-    // removed, it won't actually deallocate until the next run loop. This gives it a chance to do it.
-    [[NSRunLoop mainRunLoop] runUntilDate:[NSDate date]];
-    XCTAssertEqual([MemoryReferenceDebugger aliveObjects].count, 0u, @"%@", [MemoryReferenceDebugger aliveObjectsDescription]);
-    [MemoryReferenceDebugger reset];
++ (void)tearDown {
+    [self checkForMemoryLeaksAfterTestClassCompletes];
+    [super tearDown];
+}
+
++ (void)checkForMemoryLeaksAfterTestClassCompletes
+{
+    if ([MemoryReferenceDebugger aliveObjects].count > 0) {
+        NSLog(@"Leaked: %@", [MemoryReferenceDebugger aliveObjectsDescription]);
+        assert(false);
+    }
 }
 
 - (id<ZMSGroupQueue>)fakeUIContext {


### PR DESCRIPTION
There were too many false positives when checking for leaks in test case `tearDown`. Sometimes objects  get released later and are incorrectly marked as leaked.
Moved the check to test class `tearDown`. This gets to run after all test cases are completed and has enough time to release all objects. The drawback however is that we cannot fail any test as at that point all of them are finished, so we had to use assert that just aborts the whole test suite.