### PR TITLE
Migrate to Xcode 10 and iOS 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ defaults: &defaults
   environment:
     - DEPENDENCIES_BASE_URL: "https://raw.githubusercontent.com/wireapp/wire-ios-shared-resources/master"
   macos:
-    xcode: "9.4.0"
+    xcode: "10.0.0"
   shell: /bin/bash --login -eo pipefail
 
 # ----------------CACHING----------------

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "wireapp/ocmock" ~> 3.4
-github "wireapp/wire-ios-system" "xcode10"
+github "wireapp/wire-ios-system" ~> 24.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "wireapp/ocmock" ~> 3.4
-github "wireapp/wire-ios-system" ~> 23.0
+github "wireapp/wire-ios-system" "xcode10"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "wireapp/ocmock" "v3.4"
-github "wireapp/wire-ios-system" "23.0.0"
+github "wireapp/wire-ios-system" "99ea44634f3957652941a8e01a29b8e4668f012a"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "wireapp/ocmock" "v3.4"
-github "wireapp/wire-ios-system" "99ea44634f3957652941a8e01a29b8e4668f012a"
+github "wireapp/wire-ios-system" "24.0.0"

--- a/Source/Public/NSUUID+WireTesting.m
+++ b/Source/Public/NSUUID+WireTesting.m
@@ -19,21 +19,12 @@
 
 #import "NSUUID+WireTesting.h"
 #import <CommonCrypto/CommonCrypto.h>
-
-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
-    #import <libkern/OSAtomic.h>
-#else
-    #import <stdatomic.h>
-#endif
+#import <stdatomic.h>
 
 @implementation NSUUID (WireTesting)
 
 static uuid_t uuidBase;
-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
-    static int32_t uuidCounter;
-#else
-    static atomic_int uuidCounter;
-#endif
+static atomic_int uuidCounter;
 
 - (NSUUID *)createUUID;
 {
@@ -44,11 +35,7 @@ static uuid_t uuidBase;
 {
     uuid_t bytes;
     uuid_copy(bytes, uuidBase);
-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
-    int32_t c = OSAtomicIncrement32(&uuidCounter);
-#else
     int32_t c = atomic_fetch_add_explicit(&uuidCounter, 1, memory_order_relaxed);
-#endif
     bytes[14] = (c >> 8) & 0xff;
     bytes[15] = c & 0xff;
     NSUUID *uuid = [[NSUUID alloc] initWithUUIDBytes:bytes];

--- a/Source/Public/NSUUID+WireTesting.m
+++ b/Source/Public/NSUUID+WireTesting.m
@@ -35,7 +35,8 @@ static atomic_int uuidCounter;
 {
     uuid_t bytes;
     uuid_copy(bytes, uuidBase);
-    int32_t c = atomic_fetch_add_explicit(&uuidCounter, 1, memory_order_relaxed);
+    atomic_fetch_add_explicit(&uuidCounter, 1, memory_order_relaxed);
+    int32_t c = atomic_load(&uuidCounter);
     bytes[14] = (c >> 8) & 0xff;
     bytes[15] = c & 0xff;
     NSUUID *uuid = [[NSUUID alloc] initWithUUIDBytes:bytes];

--- a/Source/Public/XCTestCase+Helpers.swift
+++ b/Source/Public/XCTestCase+Helpers.swift
@@ -32,7 +32,7 @@ extension XCTestCase {
         }
         
         while (groupCounter > 0 && timeoutDate.timeIntervalSinceNow > 0) {
-            if !RunLoop.current.run(mode: .defaultRunLoopMode, before: Date(timeIntervalSinceNow: 0.002)) {
+            if !RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.002)) {
                 Thread.sleep(forTimeInterval: 0.002)
             }
         }

--- a/WireTesting.xcodeproj/project.pbxproj
+++ b/WireTesting.xcodeproj/project.pbxproj
@@ -388,17 +388,17 @@
 			attributes = {
 				LastSwiftMigration = 0710;
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1000;
 				ORGANIZATIONNAME = Wire;
 				TargetAttributes = {
 					096AD7BA1B68D41D00E007A8 = {
 						CreatedOnToolsVersion = 6.4;
 						DevelopmentTeam = W5KEQBF9B5;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1000;
 					};
 					096AD7C51B68D41D00E007A8 = {
 						CreatedOnToolsVersion = 6.4;
-						LastSwiftMigration = 0930;
+						LastSwiftMigration = 1000;
 					};
 				};
 			};
@@ -493,8 +493,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 54AD5CFB1EEFEEC00072FC97 /* project-debug.xcconfig */;
 			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -502,8 +504,10 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 54AD5CFC1EEFEEC00072FC97 /* project.xcconfig */;
 			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -513,6 +517,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/WireTesting.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wire.$(PRODUCT_NAME:rfc1034identifier)";
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -522,6 +527,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/WireTesting.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wire.$(PRODUCT_NAME:rfc1034identifier)";
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -534,6 +540,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Tests/WireTesting-iosTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -545,6 +552,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wire.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Tests/WireTesting-iosTests-Bridging-Header.h";
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/WireTesting.xcodeproj/xcshareddata/xcschemes/WireTesting.xcscheme
+++ b/WireTesting.xcodeproj/xcshareddata/xcschemes/WireTesting.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
## What's new in this PR?

We update the framework to compile with Xcode 10.0.

- Bump target version to iOS 10.0
- Migrate to Swift 4.2
- Remove deprecated `OSAtomicIncrement32` in UUID tests, use `atomic_fetch_add_explicit` instead

### Note

Do not merge until Jenkins uses Xcode 10 as well.
