### PR TITLE
Fail test only when logging an error

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "wireapp/ocmock" ~> 3.4
-github "wireapp/wire-ios-system" ~> 27.0
+github "wireapp/wire-ios-system" ~> 28.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "wireapp/ocmock" "v3.4.3"
-github "wireapp/wire-ios-system" "27.0.0"
+github "wireapp/wire-ios-system" "28.0.0"

--- a/Source/Public/ZMTBaseTest.m
+++ b/Source/Public/ZMTBaseTest.m
@@ -88,7 +88,7 @@
     ZM_WEAK(self);
     self.logHookToken = [ZMSLog addEntryHookWithLogHook:^(ZMLogLevel_t level, NSString * _Nullable tag, ZMSLogEntry * _Nonnull entry ) {
         ZM_STRONG(self);
-        if (!self.ignoreLogErrors && level <= ZMLogLevelWarn) {
+        if (!self.ignoreLogErrors && level == ZMLogLevelError) {
             XCTFail(@"Unexpected log error: [%@] %@", tag, entry.text);
         }
     }];


### PR DESCRIPTION
## What's new in this PR?

### Issues

After adding a new log level with https://github.com/wireapp/wire-ios-system/pull/41 some tests started to fail.

### Causes

We had logic to fail test when an error gets logged. This started misbehaving because now we also have "public" level which would fail the test.

### Solutions

To keep compatibility with current testsuite we now explicitly check if log level was "error".
