### PR TITLE
clean up duplicated checkForMemoryLeaksAfterTestClassCompletes

### DIFF
--- a/Source/Public/ZMTBaseTest.m
+++ b/Source/Public/ZMTBaseTest.m
@@ -138,14 +138,6 @@
     [super tearDown];
 }
 
-+ (void)checkForMemoryLeaksAfterTestClassCompletes
-{
-    if ([MemoryReferenceDebugger aliveObjects].count > 0) {
-        NSLog(@"Leaked: %@", [MemoryReferenceDebugger aliveObjectsDescription]);
-        assert(false);
-    }
-}
-
 - (id<ZMSGroupQueue>)fakeUIContext {
     return self.innerFakeUIContext;
 }


### PR DESCRIPTION
## What's new in this PR?

Clean up duplicate `checkForMemoryLeaksAfterTestClassCompletes` code already convert to Swift