### PR TITLE
refactor: do not extend XCTestCase

### DIFF
--- a/Source/Public/XCTestCase+Helpers.swift
+++ b/Source/Public/XCTestCase+Helpers.swift
@@ -18,14 +18,14 @@
 
 import Foundation
 
-extension XCTestCase {
+extension Array where Element == DispatchGroup {
     
-    public func waitForGroupsToBeEmpty(_ groups: [DispatchGroup], timeout: TimeInterval = 5) -> Bool {
+    public func waitForGroupsToBeEmpty(timeout: TimeInterval = 5) -> Bool {
         
         let timeoutDate = Date(timeIntervalSinceNow: timeout)
-        var groupCounter = groups.count
+        var groupCounter = count
         
-        groups.forEach { (group) in
+        forEach { (group) in
             group.notify(queue: DispatchQueue.main, execute: {
                 groupCounter -= 1
             })


### PR DESCRIPTION
# What's new in this PR?

### Issues

The XCFramework v27.1.0 cause compiler error when building utilities

### Causes

`XCTestCase` is not a member type of class `XCTest.XCTest`

### Solutions

It seems like a known error caused by namespace, put `waitForGroupsToBeEmpty` under `extension Array where Element == DispatchGroup`